### PR TITLE
Switch from JsonRpcProvider => StaticJsonRpcProvider to avoid excessive eth_chainId calls

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -29,7 +29,7 @@ if (FLASHBOTS_KEY_ID === "" || FLASHBOTS_SECRET === "") {
 
 const HEALTHCHECK_URL = process.env.HEALTHCHECK_URL || ""
 
-const provider = new providers.JsonRpcProvider(ETHEREUM_RPC_URL);
+const provider = new providers.StaticJsonRpcProvider(ETHEREUM_RPC_URL);
 
 function healthcheck() {
   if (HEALTHCHECK_URL === "") {


### PR DESCRIPTION
https://github.com/ethers-io/ethers.js/issues/901

The repeated calls to eth_chainId are more appropriate when running in a browser context when the backing rpc port could change out from under you.

@bertmiller